### PR TITLE
Sync entity deletion to firebase

### DIFF
--- a/core/src/main/java/io/github/StarvingValley/models/Interfaces/IFirebaseRepository.java
+++ b/core/src/main/java/io/github/StarvingValley/models/Interfaces/IFirebaseRepository.java
@@ -1,5 +1,6 @@
 package io.github.StarvingValley.models.Interfaces;
 
+import java.util.List;
 import java.util.Map;
 
 public interface IFirebaseRepository {
@@ -15,4 +16,5 @@ public interface IFirebaseRepository {
     
     boolean pushEntities(Map<String, Object> entityMap, PushCallback callback);
     boolean getAllEntities(EntityDataCallback callback);
+    boolean pushEntityDeletions(List<String> entityIds, PushCallback callback);
 }

--- a/core/src/main/java/io/github/StarvingValley/models/Mappers.java
+++ b/core/src/main/java/io/github/StarvingValley/models/Mappers.java
@@ -25,6 +25,7 @@ import io.github.StarvingValley.models.components.SizeComponent;
 import io.github.StarvingValley.models.components.SpeedComponent;
 import io.github.StarvingValley.models.components.SpriteComponent;
 import io.github.StarvingValley.models.components.SyncComponent;
+import io.github.StarvingValley.models.components.SyncDeletionRequestComponent;
 import io.github.StarvingValley.models.components.TileOccupierComponent;
 import io.github.StarvingValley.models.components.TileOverlapComponent;
 import io.github.StarvingValley.models.components.TiledMapComponent;
@@ -83,4 +84,7 @@ public class Mappers {
     public static final ComponentMapper<HarvestingComponent> harvesting = ComponentMapper
             .getFor(HarvestingComponent.class);
     public static final ComponentMapper<CropTypeComponent> cropType = ComponentMapper.getFor(CropTypeComponent.class);
+    public static final ComponentMapper<SyncDeletionRequestComponent> syncDeletionRequest = ComponentMapper
+                    .getFor(SyncDeletionRequestComponent.class);
+
 }

--- a/core/src/main/java/io/github/StarvingValley/models/components/SyncDeletionRequestComponent.java
+++ b/core/src/main/java/io/github/StarvingValley/models/components/SyncDeletionRequestComponent.java
@@ -1,0 +1,11 @@
+package io.github.StarvingValley.models.components;
+
+import com.badlogic.ashley.core.Component;
+
+public class SyncDeletionRequestComponent implements Component {
+    public String id;
+
+    public SyncDeletionRequestComponent(String id) {
+        this.id = id;
+    }
+}

--- a/core/src/main/java/io/github/StarvingValley/models/systems/CropGrowthSystem.java
+++ b/core/src/main/java/io/github/StarvingValley/models/systems/CropGrowthSystem.java
@@ -34,6 +34,14 @@ public class CropGrowthSystem extends IteratingSystem {
 
     growthTime.accumulateGrowth(deltaTime);
 
+    // TODO: Maybe instead of accumulation growth, we can store planting-datetime
+    // and just check time-diff? Then we don't need to sync any of this
+
+    // Don't sync fully-grown crops
+    if (growthStage.growthStage < 2) {
+      SyncUtils.markUnsynced(cropEntity);
+    }
+
     if (growthTime.growthProgress >= growthTime.timeToGrow) {
       growthStage.growthStage = 2; // mature
     } else if (growthTime.growthProgress >= growthTime.timeToGrow * 0.50) {
@@ -62,7 +70,5 @@ public class CropGrowthSystem extends IteratingSystem {
       default:
         break;
     }
-
-    SyncUtils.markUnsynced(cropEntity);
   }
 }

--- a/core/src/main/java/io/github/StarvingValley/models/systems/DurabilityRenderSystem.java
+++ b/core/src/main/java/io/github/StarvingValley/models/systems/DurabilityRenderSystem.java
@@ -11,6 +11,7 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import io.github.StarvingValley.models.Mappers;
 import io.github.StarvingValley.models.components.DurabilityComponent;
 import io.github.StarvingValley.models.components.PositionComponent;
+import io.github.StarvingValley.utils.SyncUtils;
 import io.github.StarvingValley.utils.TextureUtils;
 
 //TODO: Use shaperenderer instead and switch to entitysystem
@@ -33,6 +34,7 @@ public class DurabilityRenderSystem extends IteratingSystem {
             return;
 
         if (durabilityComponent.getHealth() <= 0) {
+            SyncUtils.markForSyncRemoval(entity, engine);
             engine.removeEntity(entity);
             return;
         }

--- a/core/src/main/java/io/github/StarvingValley/models/systems/FirebaseSyncSystem.java
+++ b/core/src/main/java/io/github/StarvingValley/models/systems/FirebaseSyncSystem.java
@@ -1,8 +1,11 @@
 package io.github.StarvingValley.models.systems;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import com.badlogic.ashley.core.Engine;
 import com.badlogic.ashley.core.Entity;
 import com.badlogic.ashley.core.Family;
 import com.badlogic.ashley.systems.IntervalSystem;
@@ -13,6 +16,7 @@ import io.github.StarvingValley.models.Mappers;
 import io.github.StarvingValley.models.Interfaces.IFirebaseRepository;
 import io.github.StarvingValley.models.Interfaces.PushCallback;
 import io.github.StarvingValley.models.components.SyncComponent;
+import io.github.StarvingValley.models.components.SyncDeletionRequestComponent;
 import io.github.StarvingValley.models.components.UnsyncedComponent;
 import io.github.StarvingValley.utils.EntitySerializer;
 
@@ -27,14 +31,28 @@ public class FirebaseSyncSystem extends IntervalSystem {
 
     @Override
     protected void updateInterval() {
-        ImmutableArray<Entity> unsyncedEntities = getEngine()
+        Engine engine = getEngine();
+
+        ImmutableArray<Entity> unsyncedEntities = engine
                 .getEntitiesFor(Family.all(SyncComponent.class, UnsyncedComponent.class).get());
+
+        ImmutableArray<Entity> entitiesMarkedForRemoval = engine
+                .getEntitiesFor(Family.all(SyncDeletionRequestComponent.class).get());
 
         Map<String, Object> batchData = new HashMap<>();
 
+        List<String> batchDeletionIds = new ArrayList<>();
+        for (Entity entity : entitiesMarkedForRemoval) {
+            SyncDeletionRequestComponent syncDeletionRequest = Mappers.syncDeletionRequest.get(entity);
+
+            batchDeletionIds.add(syncDeletionRequest.id);
+        }
+
         for (Entity entity : unsyncedEntities) {
             SyncComponent sync = Mappers.sync.get(entity);
-            System.out.println("Synced entity " + sync.id);
+            if (batchDeletionIds.contains(sync.id)) {
+                continue;
+            }
 
             Object serialized = EntitySerializer.serialize(entity);
             batchData.put(sync.id, serialized);
@@ -45,13 +63,35 @@ public class FirebaseSyncSystem extends IntervalSystem {
                 @Override
                 public void onSuccess() {
                     for (Entity entity : unsyncedEntities) {
+                        SyncComponent sync = Mappers.sync.get(entity);
+
                         entity.remove(UnsyncedComponent.class);
+                        System.out.println("Synced entity " + sync.id);
+
                     }
                 }
 
                 @Override
                 public void onFailure(String error) {
                     System.err.println("Firebase sync failed: " + error);
+                }
+            });
+        }
+
+        if (!batchDeletionIds.isEmpty()) {
+            firebaseRepository.pushEntityDeletions(batchDeletionIds, new PushCallback() {
+                @Override
+                public void onSuccess() {
+                    for (Entity entity : entitiesMarkedForRemoval) {
+                        SyncDeletionRequestComponent syncDeletionRequest = Mappers.syncDeletionRequest.get(entity);
+                        engine.removeEntity(entity);
+                        System.out.println("Deleted entity " + syncDeletionRequest.id);
+                    }
+                }
+
+                @Override
+                public void onFailure(String error) {
+                    System.err.println("Firebase deletion failed: " + error);
                 }
             });
         }

--- a/core/src/main/java/io/github/StarvingValley/models/systems/HarvestingSystem.java
+++ b/core/src/main/java/io/github/StarvingValley/models/systems/HarvestingSystem.java
@@ -18,6 +18,7 @@ import io.github.StarvingValley.models.components.HarvestingComponent;
 import io.github.StarvingValley.models.components.PlayerComponent;
 import io.github.StarvingValley.models.components.PositionComponent;
 import io.github.StarvingValley.models.components.TimeToGrowComponent;
+import io.github.StarvingValley.utils.SyncUtils;
 
 public class HarvestingSystem extends EntitySystem {
   @Override
@@ -93,8 +94,11 @@ public class HarvestingSystem extends EntitySystem {
   }
 
   private void harvestCrop(Entity crop, HarvestingComponent harvestingComponent) {
-    getEngine().removeEntity(crop);//TODO: We need to sync the removal of this somehow
-    // should be added to inventory when it exists
+    Engine engine = getEngine();
+
+    SyncUtils.markForSyncRemoval(crop, engine);
+    engine.removeEntity(crop);
+    // TODO: should be added to inventory when it exists
 
     System.out.println("Crop harvested");
   }

--- a/core/src/main/java/io/github/StarvingValley/utils/SyncUtils.java
+++ b/core/src/main/java/io/github/StarvingValley/utils/SyncUtils.java
@@ -2,10 +2,13 @@ package io.github.StarvingValley.utils;
 
 import java.util.Objects;
 
+import com.badlogic.ashley.core.Engine;
 import com.badlogic.ashley.core.Entity;
 import com.badlogic.gdx.math.Vector3;
 
 import io.github.StarvingValley.models.Mappers;
+import io.github.StarvingValley.models.components.SyncComponent;
+import io.github.StarvingValley.models.components.SyncDeletionRequestComponent;
 import io.github.StarvingValley.models.components.UnsyncedComponent;
 
 public class SyncUtils {
@@ -44,6 +47,21 @@ public class SyncUtils {
         if (Mappers.sync.has(entity)) {
             entity.remove(UnsyncedComponent.class);
         }
+    }
 
+    /**
+     * Notifies the sync to remove the entity.
+     * <b>NB! Has to be called before removing the entity from the engine</b>
+     * 
+     * @param entity
+     * @param engine
+     */
+    public static void markForSyncRemoval(Entity entity, Engine engine) {
+        SyncComponent syncComponent = Mappers.sync.get(entity);
+        if (syncComponent != null) {
+            Entity removalEntity = new Entity();
+            removalEntity.add(new SyncDeletionRequestComponent(syncComponent.id));
+            engine.addEntity(removalEntity);
+        }
     }
 }


### PR DESCRIPTION
Mark an entity from removal with `SyncUtils.markForSyncRemoval`. **Has to be called before removing the entity from the engine, since it needs SyncComponent.id**

`FirebaseSyncSystem` batch-deletes entities with ids from `SyncDeletionRequestComponent`